### PR TITLE
fix: telemetry-caused crash in undetermined runtimes

### DIFF
--- a/src/client/telemetry.ts
+++ b/src/client/telemetry.ts
@@ -4,14 +4,14 @@ export function getRuntime() {
   if (typeof process === "object" && typeof process.versions == "object" && process.versions.bun)
     return `bun@${process.versions.bun}`;
 
-  // @ts-expect-error EdgeRuntime not recognized
-  if (typeof typeof EdgeRuntime === "string") {
-    return "edge-light";
-  }
-
   if (typeof process === "object" && typeof process.version === "string") {
     return `node@${process.version}`;
   }
 
-  return "Undetermined";
+  // @ts-expect-error EdgeRuntime not recognized
+  if (typeof EdgeRuntime === "string") {
+    return "edge-light";
+  }
+
+  return "undetermined";
 }


### PR DESCRIPTION
runtimes like vite crashed because of unsafe `process` usage