### PR TITLE
fix: remove `extends Dict` generic constraint to accept TypeScript interfaces

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - published
 
 permissions:
-  id-token: write  # Required for OIDC
+  id-token: write # Required for OIDC
   contents: read
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -26,6 +26,7 @@ const results = await index.search({ query: "hello" });
 ```
 
 Basic steps:
+
 - Create an index
 - Insert or update documents
 - Run searches or filtered queries
@@ -33,7 +34,9 @@ Basic steps:
 ## Other Skill Files
 
 ### sdk-overview
+
 Provides detailed documentation for all TypeScript SDK commands. Includes:
+
 - delete: Deleting documents
 - fetch: Retrieving a document
 - info: Index info
@@ -44,7 +47,9 @@ Provides detailed documentation for all TypeScript SDK commands. Includes:
 - getting-started: Setup steps for the SDK
 
 ### quick-start
+
 Provides a fast, end-to-end workflow for creating a Search database, adding documents, and querying them. Covers essential concepts including:
+
 - Creating a database and storing credentials
 - Adding documents with content and metadata
 - Understanding content vs metadata (searchability and filterability)

--- a/skills/quick-start.md
+++ b/skills/quick-start.md
@@ -5,11 +5,13 @@ This Skill gives agents a fast, end‑to‑end workflow for creating a Search da
 ---
 
 ## Create a Database
+
 1. Open the **Vector** tab → **Create → Search Database**.
 2. Provide a name (e.g., `product-search`) and region.
 3. Select a plan.
 
 Agents should store:
+
 - `UPSTASH_SEARCH_REST_URL`
 - `UPSTASH_SEARCH_REST_TOKEN`
 
@@ -18,27 +20,31 @@ These values are required when constructing a Search client.
 ---
 
 ## Add Documents
+
 Documents consist of:
+
 - **id**: unique identifier
-- **content** *(required)*: indexed and searchable
-- **metadata** *(optional)*: **not searchable**, but retrievable and filterable
+- **content** _(required)_: indexed and searchable
+- **metadata** _(optional)_: **not searchable**, but retrievable and filterable
 
 ### TypeScript / Python Example
+
 ```ts
 import { Search } from "@upstash/search";
-const client = new Search({ 
+const client = new Search({
   url: process.env.UPSTASH_SEARCH_REST_URL,
-  token: process.env.UPSTASH_SEARCH_REST_TOKEN 
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN,
 });
 const index = client.index("movies");
 await index.upsert([
   {
     id: "star-wars",
     content: { title: "Star Wars", genre: "sci-fi", category: "classic" },
-    metadata: { director: "George Lucas" }
-  }
+    metadata: { director: "George Lucas" },
+  },
 ]);
 ```
+
 ```python
 from upstash_search import Search
 client = Search(url=URL, token=TOKEN)
@@ -58,7 +64,9 @@ index.upsert(documents=[{
 ---
 
 ## Content vs Metadata (Essential Concepts)
+
 - **Content**
+
   - Required
   - Indexed and searchable
   - Can be used in filters
@@ -71,6 +79,7 @@ index.upsert(documents=[{
   - Used for contextual / reference fields
 
 Example:
+
 ```json
 {
   "content": { "title": "Star Wars", "genre": "sci-fi" },
@@ -81,12 +90,15 @@ Example:
 ---
 
 ## Search
+
 Searching supports semantic + keyword hybrid search, optional reranking, and filters.
 
 ### TypeScript / Python Example
+
 ```ts
 const res = await index.search({ query: "space opera", limit: 2, reranking: true });
 ```
+
 ```python
 scores = index.search(query="space opera", limit=2, reranking=True)
 ```
@@ -94,32 +106,36 @@ scores = index.search(query="space opera", limit=2, reranking=True)
 ---
 
 ## Filtering
+
 Filters restrict results using SQL‑like syntax or structured filters (TypeScript only). Both **content fields** and **metadata fields** can be used.
 
 **Metadata fields require `@metadata.` prefix**.
 
 ### Example (String Filters)
+
 ```ts
 await index.search({
   query: "sony headphones",
-  filter: "warehouse_location = 'A3-15' AND @metadata.supplier_id = 'SUP-123'"
+  filter: "warehouse_location = 'A3-15' AND @metadata.supplier_id = 'SUP-123'",
 });
 ```
 
 ### Example (Type‑safe Filters, TS SDK)
+
 ```ts
 await index.search({
   query: "sony headphones",
   filter: {
     AND: [
       { category: { equals: "Electronics" } },
-      { "@metadata.count": { greaterThanOrEquals: 3 } }
-    ]
-  }
+      { "@metadata.count": { greaterThanOrEquals: 3 } },
+    ],
+  },
 });
 ```
 
 Common operators:
+
 - equals, not equals
 - <, <=, >, >=
 - glob / not glob
@@ -130,20 +146,24 @@ Common operators:
 ---
 
 ## Reranking
+
 Reranking reorders results using a high‑accuracy model.
 
 - Disabled by default (`false`)
 - When `true`, improves relevance but costs $1 per 1K reranked items
 
 Example:
+
 ```ts
 await index.search({ query: "space opera", reranking: true });
 ```
+
 ```python
 index.search(query="space opera", reranking=True)
 ```
 
 Use when:
+
 - Precision is critical
 - Results require more semantic depth
 - Queries are ambiguous or conceptual
@@ -151,6 +171,7 @@ Use when:
 ---
 
 ## Common Pitfalls
+
 - Missing **content** field → upsert fails.
 - Metadata fields are **not searchable**.
 - Metadata must be prefixed as `@metadata.key` in filters.

--- a/skills/sdk-overview.md
+++ b/skills/sdk-overview.md
@@ -12,9 +12,9 @@ You must configure a Search client using either environment variables or a confi
 import { Search } from "@upstash/search";
 
 // Option 1: with explicit config
-const client = new Search({ 
+const client = new Search({
   url: process.env.UPSTASH_SEARCH_REST_URL!,
-  token: process.env.UPSTASH_SEARCH_REST_TOKEN! 
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
 });
 const index = client.index("movies");
 
@@ -25,8 +25,9 @@ const index2 = client2.index("movies");
 ```
 
 Type-safe usage:
+
 ```ts
-type Content = { title: string, genre: string };
+type Content = { title: string; genre: string };
 type Metadata = { year: number };
 const indexTyped = client.index<Content, Metadata>("movies");
 ```
@@ -36,6 +37,7 @@ const indexTyped = client.index<Content, Metadata>("movies");
 ## Upsert (add or update documents)
 
 Pitfalls:
+
 - Document structure must match the index schema.
 - Content/metadata types are enforced when using generics.
 
@@ -44,7 +46,7 @@ Pitfalls:
 await index.upsert({
   id: "star-wars",
   content: { title: "Star Wars", genre: "sci-fi" },
-  metadata: { year: 1977 }
+  metadata: { year: 1977 },
 });
 
 // Multiple
@@ -62,6 +64,7 @@ await index.upsert({ id: "star-wars", content: { title: "A New Hope" } });
 ## Fetch (retrieve documents)
 
 Pitfalls:
+
 - Returns null for IDs not found.
 - Supports prefix matching.
 
@@ -78,8 +81,9 @@ const sciFi = await index.fetch({ prefix: "star-" });
 ## Delete (IDs, prefix, or filter)
 
 Pitfalls:
+
 - **Filter deletion is O(N)** and slow on large indexes.
-- Prefix deletion removes *all* matching documents.
+- Prefix deletion removes _all_ matching documents.
 
 ```ts
 // ID list
@@ -100,6 +104,7 @@ await index.delete({ filter: "age > 30" });
 ## Search (AI‑powered)
 
 Pitfalls:
+
 - Default `limit = 5`.
 - Scores are 0–1.
 - Use filters to restrict by document fields.
@@ -123,6 +128,7 @@ await index.search({ query: "robots", semanticWeight: 0.2 });
 ## Range (cursor pagination)
 
 Pitfalls:
+
 - Stateless: you must pass all parameters every call.
 - `cursor = "0"` for the first request.
 

--- a/src/search-index.ts
+++ b/src/search-index.ts
@@ -13,7 +13,7 @@ import type { Dict, VectorIndex, UpsertParameters, SearchResult, Document } from
  * @template TContent - Content shape associated with each document.
  * @template TIndexMetadata - Metadata shape associated with each document.
  */
-export class SearchIndex<TContent extends Dict = Dict, TIndexMetadata extends Dict = Dict> {
+export class SearchIndex<TContent = Dict, TIndexMetadata = Dict> {
   /**
    * Initializes a new SearchIndex instance for the specified index.
    *

--- a/src/search.ts
+++ b/src/search.ts
@@ -27,7 +27,7 @@ export class Search {
    * @param indexName - The name to use as an index.
    * @returns A SearchIndex instance for managing documents within the index.
    */
-  index = <TContent extends Dict = Dict, TIndexMetadata extends Dict = Dict>(
+  index = <TContent = Dict, TIndexMetadata = Dict>(
     indexName: string
   ): SearchIndex<TContent, TIndexMetadata> => {
     return new SearchIndex<TContent, TIndexMetadata>(this.client, this.vectorIndex, indexName);

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,19 +8,11 @@ export type UpsertParameters<TContent = Dict, TIndexMetadata = Dict> = {
   metadata?: TIndexMetadata;
 };
 
-export type Document<
-  TContent = Dict,
-  TMetadata = Dict,
-  TWithScore extends boolean = false,
-> = {
+export type Document<TContent = Dict, TMetadata = Dict, TWithScore extends boolean = false> = {
   id: string;
   content: TContent;
   metadata?: TMetadata;
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 } & (TWithScore extends true ? { score: number } : {});
 
-export type SearchResult<TContent = Dict, TMetadata = Dict> = Document<
-  TContent,
-  TMetadata,
-  true
->[];
+export type SearchResult<TContent = Dict, TMetadata = Dict> = Document<TContent, TMetadata, true>[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,15 +2,15 @@ export type { QueryResult, Index as VectorIndex } from "@upstash/vector";
 
 export type Dict = Record<string, unknown>;
 
-export type UpsertParameters<TContent extends Dict, TIndexMetadata extends Dict> = {
+export type UpsertParameters<TContent = Dict, TIndexMetadata = Dict> = {
   id: string;
   content: TContent;
   metadata?: TIndexMetadata;
 };
 
 export type Document<
-  TContent extends Dict,
-  TMetadata extends Dict,
+  TContent = Dict,
+  TMetadata = Dict,
   TWithScore extends boolean = false,
 > = {
   id: string;
@@ -19,7 +19,7 @@ export type Document<
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 } & (TWithScore extends true ? { score: number } : {});
 
-export type SearchResult<TContent extends Dict, TMetadata extends Dict> = Document<
+export type SearchResult<TContent = Dict, TMetadata = Dict> = Document<
   TContent,
   TMetadata,
   true


### PR DESCRIPTION
## Summary

- Remove `extends Dict` constraint from all generic type parameters across `SearchIndex`, `Search.index()`, `UpsertParameters`, `Document`, and `SearchResult`
- Keep `Dict` (`Record<string, unknown>`) as the default type argument (`= Dict`) so untyped usage remains unchanged
- TypeScript interfaces lack implicit index signatures and cannot satisfy `extends Record<string, unknown>`, causing type errors when users pass their own interfaces as type parameters

## Test plan

- [x] `bun run build` passes successfully
- [x] Verify that existing tests still pass
- [x] Verify that TypeScript `interface` declarations can now be used as type parameters without errors

Closes #16